### PR TITLE
Avoid property undefined

### DIFF
--- a/src/About.js
+++ b/src/About.js
@@ -20,8 +20,8 @@ export default function About(props) {
         <div className="w-3/12 m-auto bg-purple-100 mt-4 shadow-2xl flex justify-center flex-col items-center">
           <h3 className="text-2xl text-green-900 uppercase">{pokemon.name}</h3>
           <div className="flex justify-center">
-            <img className="w-48" src={pokemon.sprites["front_shiny"]} alt="" />
-            <img className="w-48" src={pokemon.sprites["back_shiny"]} alt="" />
+            <img className="w-48" src={pokemon.sprites?.front_shiny} alt="" />
+            <img className="w-48" src={pokemon.sprites?.back_shiny} alt="" />
           </div>
         </div>
       )}


### PR DESCRIPTION
Use **optional chaining** (`?.`) to prevent the following property undefined errors:

> TypeError: Cannot read property 'front_shiny' of undefined
> TypeError: Cannot read property 'back_shiny' of undefined